### PR TITLE
Removed linux check when starting emulator

### DIFF
--- a/step.rb
+++ b/step.rb
@@ -145,7 +145,6 @@ begin
     os = `uname -s 2>&1`
 
     emulator = File.join(ENV['android_home'], 'tools/emulator')
-    emulator = File.join(ENV['android_home'], 'tools/emulator64-arm') if os.include? 'Linux'
 
     params = [emulator, '-avd', emulator_name]
     params << '-no-boot-anim' # Disable the boot animation during emulator startup.


### PR DESCRIPTION
By using tools/emulator (which exists in Linux Android SDK releases) we allow to run x86 AVDs. By using tools/emulator64-arm the x86 AVDs do not start. x86 are 10x faster than arm ones so it's important to allow them to run
