### PR TITLE
Fixed emulator start on Google APIs level 25 system image

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,8 +5,8 @@ app:
   envs:
   - RELEASE_VERSION: 1.2.1
 
-  - BITRISE_EMULATOR_NAME: android-22-armeabi-v7a
-  - EMULATOR_PLATFORM: android-22
+  - BITRISE_EMULATOR_NAME: android-25-armeabi-v7a
+  - EMULATOR_PLATFORM: android-25
   - EMULATOR_TAG: google_apis
 
 workflows:

--- a/vendor/github.com/bitrise-tools/go-android/emulatormanager/emulatormanager.go
+++ b/vendor/github.com/bitrise-tools/go-android/emulatormanager/emulatormanager.go
@@ -13,18 +13,11 @@ import (
 // Model ...
 type Model struct {
 	binPth string
-	env    string
 }
 
 // New ...
 func New(sdk sdk.AndroidSdkInterface) (*Model, error) {
 	binPth := filepath.Join(sdk.GetAndroidHome(), "emulator", "emulator")
-	env := ""
-	if runtime.GOOS == "linux" {
-		binPth = filepath.Join(sdk.GetAndroidHome(), "emulator", "emulator64-arm")
-		env = "LD_LIBRARY_PATH=" + filepath.Join(sdk.GetAndroidHome(), "emulator", "lib64", "qt", "lib")
-	}
-
 	exist, err := pathutil.IsPathExists(binPth)
 	if err != nil {
 		return nil, err
@@ -43,7 +36,6 @@ func New(sdk sdk.AndroidSdkInterface) (*Model, error) {
 
 	return &Model{
 		binPth: binPth,
-		env: env,
 	}, nil
 }
 
@@ -59,5 +51,5 @@ func (model Model) StartEmulatorCommand(name, skin string, options ...string) *c
 
 	args = append(args, options...)
 
-	return command.New(args[0], args[1:]...).AppendEnvs(model.env)
+	return command.New(args[0], args[1:]...)
 }

--- a/vendor/github.com/bitrise-tools/go-android/emulatormanager/emulatormanager.go
+++ b/vendor/github.com/bitrise-tools/go-android/emulatormanager/emulatormanager.go
@@ -13,11 +13,18 @@ import (
 // Model ...
 type Model struct {
 	binPth string
+	env    string
 }
 
 // New ...
 func New(sdk sdk.AndroidSdkInterface) (*Model, error) {
 	binPth := filepath.Join(sdk.GetAndroidHome(), "emulator", "emulator")
+	env := ""
+	if runtime.GOOS == "linux" {
+		binPth = filepath.Join(sdk.GetAndroidHome(), "emulator", "emulator64-arm")
+		env = "LD_LIBRARY_PATH=" + filepath.Join(sdk.GetAndroidHome(), "emulator", "lib64", "qt", "lib")
+	}
+
 	exist, err := pathutil.IsPathExists(binPth)
 	if err != nil {
 		return nil, err
@@ -36,6 +43,7 @@ func New(sdk sdk.AndroidSdkInterface) (*Model, error) {
 
 	return &Model{
 		binPth: binPth,
+		env: env,
 	}, nil
 }
 
@@ -51,5 +59,5 @@ func (model Model) StartEmulatorCommand(name, skin string, options ...string) *c
 
 	args = append(args, options...)
 
-	return command.New(args[0], args[1:]...)
+	return command.New(args[0], args[1:]...).AppendEnvs(model.env)
 }


### PR DESCRIPTION
Previously AVD using `system-images;android-25;google_apis;armeabi-v7a` had a bootloop, at least on Linux.
This also fixes warnings:
```
sh: 1: lspci: not found
sh: 1: glxinfo: not found
pulseaudio: pa_context_connect() failed
pulseaudio: Reason: Connection refused
pulseaudio: Failed to initialize PA contextaudio: Could not init `pa' audio driver
```