### PR TITLE
-no-audio added to default options

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -34,7 +34,7 @@ inputs:
       description: |
         Use this input to specify an emulator skin.
         Value example: `768x1280`.
-  - emulator_options: "-no-boot-anim -no-window"
+  - emulator_options: "-no-boot-anim -no-window -no-audio"
     opts:
       title: Specify emulator command's flags
       description: |-


### PR DESCRIPTION
Fixes warning `emulator: warning: opening audio output failed`.
Audio output devices are usually not present on CI machines including docker containers on bitrise.io